### PR TITLE
fix: resolve cncli CPU spike and sqlite contention with parallel slot leader refresh

### DIFF
--- a/cmd/watcher/app/config/config.go
+++ b/cmd/watcher/app/config/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	PoolWatcherConfig    PoolWatcherConfig    `mapstructure:"pool-watcher"`
 	NetworkWatcherConfig NetworkWatcherConfig `mapstructure:"network-watcher"`
 	StatusWatcherConfig  StatusWatcherConfig  `mapstructure:"status-watcher"`
+	SlotLeaderConfig     SlotLeaderConfig     `mapstructure:"slot-leader"`
+}
+
+type SlotLeaderConfig struct {
+	Concurrency int `mapstructure:"concurrency"`
 }
 
 type BlockWatcherConfig struct {

--- a/cmd/watcher/app/watcher.go
+++ b/cmd/watcher/app/watcher.go
@@ -99,6 +99,7 @@ func NewWatcherCommand() *cobra.Command {
 	cmd.Flags().IntP("pool-watcher-refresh-interval", "", 60, "Interval at which the pool watcher collects data about the monitored pools (in seconds)")
 	cmd.Flags().BoolP("block-watcher-enabled", "", true, "Enable block watcher")
 	cmd.Flags().IntP("block-watcher-refresh-interval", "", 60, "Interval at which the block watcher collects and process slots (in seconds)")
+	cmd.Flags().IntP("slot-leader-concurrency", "", 0, "max concurrent cncli leaderlog processes (0 = unlimited)")
 
 	// bind flag to viper
 	checkError(viper.BindPFlag("log-level", cmd.Flag("log-level")), "unable to bind log-level flag")
@@ -122,6 +123,7 @@ func NewWatcherCommand() *cobra.Command {
 	checkError(viper.BindPFlag("pool-watcher.refresh-interval", cmd.Flag("pool-watcher-refresh-interval")), "unable to bind pool-watcher-refresh-interval flag")
 	checkError(viper.BindPFlag("block-watcher.enabled", cmd.Flag("block-watcher-enabled")), "unable to bind block-watcher-enabled flag")
 	checkError(viper.BindPFlag("block-watcher.refresh-interval", cmd.Flag("block-watcher-refresh-interval")), "unable to bind block-watcher-refresh-interval flag")
+	checkError(viper.BindPFlag("slot-leader.concurrency", cmd.Flag("slot-leader-concurrency")), "unable to bind slot-leader-concurrency flag")
 
 	return cmd
 }
@@ -213,10 +215,17 @@ func run(_ *cobra.Command, _ []string) error {
 	}
 
 	// Launch slot leader calculation for the current slot
-	slotLeaderService := slotleader.NewSlotLeaderService(database.DB, cardano, blockfrost, cfg.Pools, metrics)
-	if err := slotLeaderService.Refresh(ctx, epoch); err != nil {
+	slotLeaderService := slotleader.NewSlotLeaderService(database.DB, cardano, blockfrost, cfg.Pools, metrics, cfg.SlotLeaderConfig.Concurrency)
+	if err := slotLeaderService.RefreshCurrent(ctx, epoch); err != nil {
 		return fmt.Errorf("unable to refresh slot leaders: %w", err)
 	}
+
+	eg.Go(func() error {
+		logger.InfoContext(ctx, "starting next epoch scheduler",
+			slog.String("component", "next-epoch-scheduler"),
+		)
+		return slotLeaderService.RunNextEpochScheduler(ctx)
+	})
 
 	healthStore := watcher.NewHealthStore()
 
@@ -280,7 +289,6 @@ func createCardanoClient(blockfrost blockfrost.Client, socketPath string) cardan
 		Network:    cfg.Network,
 		SocketPath: socketPath,
 		Timezone:   cfg.Cardano.Timezone,
-		DBPath:     cfg.Database.Path,
 	}
 	return cardanocli.NewClient(opts, blockfrost, &cardanocli.RealCommandExecutor{})
 }

--- a/internal/cardano/cardano.go
+++ b/internal/cardano/cardano.go
@@ -7,7 +7,7 @@ import (
 )
 
 type CardanoClient interface {
-	LeaderLogs(ctx context.Context, ledgetSet string, epochNonce string, pool pools.Pool) error
+	LeaderLogs(ctx context.Context, ledgerSet string, epochNonce string, pool pools.Pool) (ClientLeaderLogsResponse, error)
 	StakeSnapshot(ctx context.Context, PoolID string) (ClientQueryStakeSnapshotResponse, error)
 	Ping(ctx context.Context) error
 }

--- a/internal/cardano/cardanocli/cardano.go
+++ b/internal/cardano/cardanocli/cardano.go
@@ -2,6 +2,7 @@ package cardanocli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/kilnfi/cardano-validator-watcher/internal/blockfrost"
 	"github.com/kilnfi/cardano-validator-watcher/internal/cardano"
@@ -33,7 +36,6 @@ type Client struct {
 var _ cardano.CardanoClient = (*Client)(nil)
 
 type ClientOptions struct {
-	DBPath     string
 	ConfigDir  string
 	Network    string
 	SocketPath string
@@ -118,20 +120,38 @@ func (c *Client) StakeSnapshot(ctx context.Context, PoolID string) (cardano.Clie
 	return response, nil
 }
 
-func (c *Client) LeaderLogs(ctx context.Context, ledgetSet string, epochNonce string, pool pools.Pool) error {
+func (c *Client) LeaderLogs(ctx context.Context, ledgerSet string, epochNonce string, pool pools.Pool) (cardano.ClientLeaderLogsResponse, error) {
 	byronGenesisfile := filepath.Join(c.opts.ConfigDir, "byron.json")
 	shelleyGenesisfile := filepath.Join(c.opts.ConfigDir, "shelley.json")
 	if _, err := os.Stat(byronGenesisfile); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("unable to find byron genesis file: %w", err)
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to find byron genesis file: %w", err)
 	}
 
 	if _, err := os.Stat(shelleyGenesisfile); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("unable to find shelley genesis file: %w", err)
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to find shelley genesis file: %w", err)
 	}
 
 	if _, err := os.Stat(pool.Key); errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("unable to find pool vrf skey file: %w", err)
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to find pool vrf skey file: %w", err)
 	}
+
+	tmpFile, err := os.CreateTemp("", "cncli-*.db")
+	if err != nil {
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to create temp db for cncli: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath) //nolint:errcheck
+
+	tmpDB, err := sql.Open("sqlite3", tmpPath)
+	if err != nil {
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to initialize temp db for cncli: %w", err)
+	}
+	if _, err := tmpDB.ExecContext(ctx, "PRAGMA user_version = 1"); err != nil {
+		tmpDB.Close()
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to initialize temp db for cncli: %w", err)
+	}
+	tmpDB.Close()
 
 	args := []string{
 		"leaderlog",
@@ -140,7 +160,7 @@ func (c *Client) LeaderLogs(ctx context.Context, ledgetSet string, epochNonce st
 		"--shelley-genesis",
 		shelleyGenesisfile,
 		"--ledger-set",
-		ledgetSet,
+		ledgerSet,
 		"--nonce",
 		epochNonce,
 		"--pool-id",
@@ -150,20 +170,20 @@ func (c *Client) LeaderLogs(ctx context.Context, ledgetSet string, epochNonce st
 		"--tz",
 		c.opts.Timezone,
 		"--db",
-		c.opts.DBPath,
+		tmpPath,
 	}
 
 	poolInfo, err := c.blockfrost.GetPoolInfo(ctx, pool.ID)
 	if err != nil {
-		return fmt.Errorf("unable to fetch pool info for %s: %w", pool.ID, err)
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to fetch pool info for %s: %w", pool.ID, err)
 	}
 
 	poolstakeSnapshot, err := c.StakeSnapshot(ctx, poolInfo.PoolID)
 	if err != nil {
-		return err
+		return cardano.ClientLeaderLogsResponse{}, err
 	}
 
-	switch ledgetSet {
+	switch ledgerSet {
 	case "prev":
 		args = append(args, "--pool-stake", strconv.Itoa(poolstakeSnapshot.Pools[poolInfo.Hex].StakeGo))
 		args = append(args, "--active-stake", strconv.Itoa(poolstakeSnapshot.Total.StakeGo))
@@ -186,19 +206,17 @@ func (c *Client) LeaderLogs(ctx context.Context, ledgetSet string, epochNonce st
 			slog.String("pool_id", pool.ID),
 		)
 		fmt.Fprint(os.Stdout, string(output))
-		return fmt.Errorf("cncli leaderlog: %w", err)
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("cncli leaderlog: %w", err)
 	}
 
 	response := cardano.ClientLeaderLogsResponse{}
 	if err := json.Unmarshal(output, &response); err != nil {
-		return fmt.Errorf("unable to unmarshal response for leaderlog command: %w", err)
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to unmarshal response for leaderlog command: %w", err)
 	}
 
-	// catch errors from the cncli command when it returns an exit status of 0
-	// despite encountering an issue.
 	if response.Status == "error" {
-		return fmt.Errorf("cncli leaderlog: %s", response.ErrorMessage)
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("cncli leaderlog: %s", response.ErrorMessage)
 	}
 
-	return nil
+	return response, nil
 }

--- a/internal/cardano/cardanocli/cardano_test.go
+++ b/internal/cardano/cardanocli/cardano_test.go
@@ -134,7 +134,6 @@ func TestLeaderLogs(t *testing.T) {
 	clientopts := ClientOptions{
 		Network:    "preprod",
 		SocketPath: "/tmp/cardano.socket",
-		DBPath:     "db.db",
 		Timezone:   "UTC",
 	}
 	bf := blockfrostmocks.NewMockClient(t)
@@ -230,7 +229,7 @@ func TestLeaderLogs(t *testing.T) {
 		"--tz",
 		clientopts.Timezone,
 		"--db",
-		clientopts.DBPath,
+		mock.AnythingOfType("string"),
 		"--pool-stake",
 		strconv.Itoa(expected.Pools["pool-0-hex"].StakeSet),
 		"--active-stake",
@@ -238,6 +237,7 @@ func TestLeaderLogs(t *testing.T) {
 	).Return(expectedOutputByte, nil)
 
 	client := NewClient(clientopts, bf, exec)
-	err = client.LeaderLogs(ctx, "current", "nonce", pool)
+	response, err := client.LeaderLogs(ctx, "current", "nonce", pool)
 	require.NoError(t, err)
+	require.Equal(t, expectedOutput, response)
 }

--- a/internal/cardano/mocks/mock_CardanoClient.go
+++ b/internal/cardano/mocks/mock_CardanoClient.go
@@ -25,22 +25,32 @@ func (_m *MockCardanoClient) EXPECT() *MockCardanoClient_Expecter {
 	return &MockCardanoClient_Expecter{mock: &_m.Mock}
 }
 
-// LeaderLogs provides a mock function with given fields: ctx, ledgetSet, epochNonce, pool
-func (_m *MockCardanoClient) LeaderLogs(ctx context.Context, ledgetSet string, epochNonce string, pool pools.Pool) error {
-	ret := _m.Called(ctx, ledgetSet, epochNonce, pool)
+// LeaderLogs provides a mock function with given fields: ctx, ledgerSet, epochNonce, pool
+func (_m *MockCardanoClient) LeaderLogs(ctx context.Context, ledgerSet string, epochNonce string, pool pools.Pool) (cardano.ClientLeaderLogsResponse, error) {
+	ret := _m.Called(ctx, ledgerSet, epochNonce, pool)
 
 	if len(ret) == 0 {
 		panic("no return value specified for LeaderLogs")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, pools.Pool) error); ok {
-		r0 = rf(ctx, ledgetSet, epochNonce, pool)
+	var r0 cardano.ClientLeaderLogsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, pools.Pool) (cardano.ClientLeaderLogsResponse, error)); ok {
+		return rf(ctx, ledgerSet, epochNonce, pool)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, pools.Pool) cardano.ClientLeaderLogsResponse); ok {
+		r0 = rf(ctx, ledgerSet, epochNonce, pool)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(cardano.ClientLeaderLogsResponse)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, pools.Pool) error); ok {
+		r1 = rf(ctx, ledgerSet, epochNonce, pool)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockCardanoClient_LeaderLogs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LeaderLogs'
@@ -50,26 +60,26 @@ type MockCardanoClient_LeaderLogs_Call struct {
 
 // LeaderLogs is a helper method to define mock.On call
 //   - ctx context.Context
-//   - ledgetSet string
+//   - ledgerSet string
 //   - epochNonce string
 //   - pool pools.Pool
-func (_e *MockCardanoClient_Expecter) LeaderLogs(ctx interface{}, ledgetSet interface{}, epochNonce interface{}, pool interface{}) *MockCardanoClient_LeaderLogs_Call {
-	return &MockCardanoClient_LeaderLogs_Call{Call: _e.mock.On("LeaderLogs", ctx, ledgetSet, epochNonce, pool)}
+func (_e *MockCardanoClient_Expecter) LeaderLogs(ctx interface{}, ledgerSet interface{}, epochNonce interface{}, pool interface{}) *MockCardanoClient_LeaderLogs_Call {
+	return &MockCardanoClient_LeaderLogs_Call{Call: _e.mock.On("LeaderLogs", ctx, ledgerSet, epochNonce, pool)}
 }
 
-func (_c *MockCardanoClient_LeaderLogs_Call) Run(run func(ctx context.Context, ledgetSet string, epochNonce string, pool pools.Pool)) *MockCardanoClient_LeaderLogs_Call {
+func (_c *MockCardanoClient_LeaderLogs_Call) Run(run func(ctx context.Context, ledgerSet string, epochNonce string, pool pools.Pool)) *MockCardanoClient_LeaderLogs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(pools.Pool))
 	})
 	return _c
 }
 
-func (_c *MockCardanoClient_LeaderLogs_Call) Return(_a0 error) *MockCardanoClient_LeaderLogs_Call {
-	_c.Call.Return(_a0)
+func (_c *MockCardanoClient_LeaderLogs_Call) Return(_a0 cardano.ClientLeaderLogsResponse, _a1 error) *MockCardanoClient_LeaderLogs_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockCardanoClient_LeaderLogs_Call) RunAndReturn(run func(context.Context, string, string, pools.Pool) error) *MockCardanoClient_LeaderLogs_Call {
+func (_c *MockCardanoClient_LeaderLogs_Call) RunAndReturn(run func(context.Context, string, string, pools.Pool) (cardano.ClientLeaderLogsResponse, error)) *MockCardanoClient_LeaderLogs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/slotleader/mocks/mock_SlotLeader.go
+++ b/internal/slotleader/mocks/mock_SlotLeader.go
@@ -259,12 +259,12 @@ func (_c *MockSlotLeader_IsSlotsEmpty_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
-// Refresh provides a mock function with given fields: ctx, epoch
-func (_m *MockSlotLeader) Refresh(ctx context.Context, epoch blockfrost.Epoch) error {
+// RefreshCurrent provides a mock function with given fields: ctx, epoch
+func (_m *MockSlotLeader) RefreshCurrent(ctx context.Context, epoch blockfrost.Epoch) error {
 	ret := _m.Called(ctx, epoch)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Refresh")
+		panic("no return value specified for RefreshCurrent")
 	}
 
 	var r0 error
@@ -277,31 +277,31 @@ func (_m *MockSlotLeader) Refresh(ctx context.Context, epoch blockfrost.Epoch) e
 	return r0
 }
 
-// MockSlotLeader_Refresh_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Refresh'
-type MockSlotLeader_Refresh_Call struct {
+// MockSlotLeader_RefreshCurrent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RefreshCurrent'
+type MockSlotLeader_RefreshCurrent_Call struct {
 	*mock.Call
 }
 
-// Refresh is a helper method to define mock.On call
+// RefreshCurrent is a helper method to define mock.On call
 //   - ctx context.Context
 //   - epoch blockfrost.Epoch
-func (_e *MockSlotLeader_Expecter) Refresh(ctx interface{}, epoch interface{}) *MockSlotLeader_Refresh_Call {
-	return &MockSlotLeader_Refresh_Call{Call: _e.mock.On("Refresh", ctx, epoch)}
+func (_e *MockSlotLeader_Expecter) RefreshCurrent(ctx interface{}, epoch interface{}) *MockSlotLeader_RefreshCurrent_Call {
+	return &MockSlotLeader_RefreshCurrent_Call{Call: _e.mock.On("RefreshCurrent", ctx, epoch)}
 }
 
-func (_c *MockSlotLeader_Refresh_Call) Run(run func(ctx context.Context, epoch blockfrost.Epoch)) *MockSlotLeader_Refresh_Call {
+func (_c *MockSlotLeader_RefreshCurrent_Call) Run(run func(ctx context.Context, epoch blockfrost.Epoch)) *MockSlotLeader_RefreshCurrent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(blockfrost.Epoch))
 	})
 	return _c
 }
 
-func (_c *MockSlotLeader_Refresh_Call) Return(_a0 error) *MockSlotLeader_Refresh_Call {
+func (_c *MockSlotLeader_RefreshCurrent_Call) Return(_a0 error) *MockSlotLeader_RefreshCurrent_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockSlotLeader_Refresh_Call) RunAndReturn(run func(context.Context, blockfrost.Epoch) error) *MockSlotLeader_Refresh_Call {
+func (_c *MockSlotLeader_RefreshCurrent_Call) RunAndReturn(run func(context.Context, blockfrost.Epoch) error) *MockSlotLeader_RefreshCurrent_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/slotleader/slotleader.go
+++ b/internal/slotleader/slotleader.go
@@ -3,9 +3,11 @@ package slotleader
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strconv"
+	"time"
 
 	bfAPI "github.com/blockfrost/blockfrost-go"
 	"github.com/jmoiron/sqlx"
@@ -24,34 +26,61 @@ func NewSlotLeaderService(
 	blockfrost blockfrost.Client,
 	pools pools.Pools,
 	metrics *metrics.Collection,
+	concurrency int,
 ) *Service {
 	logger := slog.With(
 		slog.String("component", "slot-leader-service"),
 	)
 
 	return &Service{
-		db:         db,
-		logger:     logger,
-		pools:      pools,
-		cardano:    cardanocli,
-		blockfrost: blockfrost,
-		metrics:    metrics,
+		db:          db,
+		logger:      logger,
+		pools:       pools,
+		cardano:     cardanocli,
+		blockfrost:  blockfrost,
+		metrics:     metrics,
+		concurrency: concurrency,
 	}
 }
 
+func (s *Service) RefreshCurrent(ctx context.Context, epoch bfAPI.Epoch) error {
+	return s.refresh(ctx, epoch, "current", s.concurrency)
+}
+
+func (s *Service) RefreshNext(ctx context.Context, epoch bfAPI.Epoch, concurrency int) error {
+	return s.refresh(ctx, epoch, "next", concurrency)
+}
+
 //nolint:wrapcheck
-func (s *Service) Refresh(ctx context.Context, epoch bfAPI.Epoch) error {
+func (s *Service) refresh(ctx context.Context, epoch bfAPI.Epoch, ledgerSet string, concurrency int) error {
 	eg := errgroup.Group{}
+	if concurrency > 0 {
+		eg.SetLimit(concurrency)
+	}
+
+	activePools := s.pools.GetActivePools()
+	if concurrency > 0 {
+		s.logger.InfoContext(ctx, "🔄 refreshing slot leaders",
+			slog.Int("pools", len(activePools)),
+			slog.Int("concurrency", concurrency),
+			slog.Int("epoch", epoch.Epoch),
+		)
+	} else {
+		s.logger.InfoContext(ctx, "🔄 refreshing slot leaders",
+			slog.Int("pools", len(activePools)),
+			slog.String("concurrency", "unlimited"),
+			slog.Int("epoch", epoch.Epoch),
+		)
+	}
 
 	epochParams, err := s.blockfrost.GetEpochParameters(ctx, epoch.Epoch)
 	if err != nil {
 		return fmt.Errorf("slotLeader: unable to get epoch parameters: %w", err)
 	}
 
-	for _, pool := range s.pools.GetActivePools() {
+	for _, pool := range activePools {
 		eg.Go(func(pool pools.Pool) func() error {
 			return func() error {
-				// check if we have already refreshed the slots for this pool
 				refreshed, err := s.isRefresh(ctx, pool.ID, epoch.Epoch)
 				if err != nil {
 					return fmt.Errorf("unable to check if slots are already refreshed for %s: %w", pool.Name, err)
@@ -62,9 +91,19 @@ func (s *Service) Refresh(ctx context.Context, epoch bfAPI.Epoch) error {
 						fmt.Sprintf("⏰ refreshing slots for pool: %s", pool.Name),
 						slog.String("pool_id", pool.ID),
 					)
-					if err := s.cardano.LeaderLogs(ctx, "current", epochParams.Nonce, pool); err != nil {
+					response, err := s.cardano.LeaderLogs(ctx, ledgerSet, epochParams.Nonce, pool)
+					if err != nil {
 						return &ErrSlotLeaderRefresh{PoolID: pool.ID, Epoch: epoch.Epoch, Message: err.Error()}
 					}
+					if err := s.persistSlots(ctx, pool.ID, epoch.Epoch, response); err != nil {
+						return fmt.Errorf("unable to persist slots for pool %s: %w", pool.Name, err)
+					}
+					s.logger.InfoContext(ctx,
+						fmt.Sprintf("✅ slots persisted for pool: %s", pool.Name),
+						slog.String("pool_id", pool.ID),
+						slog.Int("epoch", epoch.Epoch),
+						slog.Int("slot_count", len(response.AssignedSlots)),
+					)
 				} else {
 					s.logger.InfoContext(ctx,
 						fmt.Sprintf("💠 slots already refreshed for pool: %s", pool.Name),
@@ -82,6 +121,52 @@ func (s *Service) Refresh(ctx context.Context, epoch bfAPI.Epoch) error {
 		}(pool))
 	}
 	return eg.Wait()
+}
+
+func (s *Service) RunNextEpochScheduler(ctx context.Context) error {
+	ticker := time.NewTicker(30 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			epoch, err := s.blockfrost.GetLatestEpoch(ctx)
+			if err != nil {
+				s.logger.ErrorContext(ctx, "🚨 next-epoch-scheduler: unable to get latest epoch",
+					slog.String("error", err.Error()),
+				)
+				continue
+			}
+
+			timeUntilEnd := time.Until(time.Unix(int64(epoch.EndTime), 0).UTC())
+			s.logger.DebugContext(ctx, "🔍 next-epoch-scheduler: checking epoch end time",
+				slog.Int("current_epoch", epoch.Epoch),
+				slog.String("time_until_end", timeUntilEnd.Round(time.Minute).String()),
+			)
+
+			if timeUntilEnd > 24*time.Hour {
+				continue
+			}
+
+			nextEpoch := bfAPI.Epoch{Epoch: epoch.Epoch + 1}
+			s.logger.InfoContext(ctx, "⏩ pre-computing next epoch slot schedule",
+				slog.Int("next_epoch", nextEpoch.Epoch),
+				slog.String("next_epoch_in", timeUntilEnd.Round(time.Minute).String()),
+			)
+			if err := s.RefreshNext(ctx, nextEpoch, s.concurrency); err != nil {
+				s.logger.ErrorContext(ctx, "🚨 next-epoch-scheduler: unable to pre-compute next epoch",
+					slog.Int("next_epoch", nextEpoch.Epoch),
+					slog.String("error", err.Error()),
+				)
+				continue
+			}
+			s.logger.InfoContext(ctx, "✅ next epoch slot schedule pre-computed successfully",
+				slog.Int("next_epoch", nextEpoch.Epoch),
+			)
+		}
+	}
 }
 
 func (s *Service) GetSlotLeaders(ctx context.Context, PoolID string, epoch int) (Schedule, error) {
@@ -155,4 +240,22 @@ func (s *Service) IsSlotsEmpty(ctx context.Context, PoolID string, epoch int) (b
 	}
 
 	return len(schedule[0].Slots) == 0 || schedule[0].Quantity == 0, nil
+}
+
+func (s *Service) persistSlots(ctx context.Context, poolID string, epoch int, response cardano.ClientLeaderLogsResponse) error {
+	assignedSlots := make([]int, len(response.AssignedSlots))
+	for i, slot := range response.AssignedSlots {
+		assignedSlots[i] = slot.Slot
+	}
+
+	slotsJSON, err := json.Marshal(assignedSlots)
+	if err != nil {
+		return fmt.Errorf("unable to marshal slots: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO slots (epoch, pool_id, slot_qty, slots, hash) VALUES (?, ?, ?, ?, ?)`,
+		epoch, poolID, len(assignedSlots), string(slotsJSON), "",
+	)
+	return err
 }

--- a/internal/slotleader/slotleader_test.go
+++ b/internal/slotleader/slotleader_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kilnfi/cardano-validator-watcher/internal/cardano"
 )
 
 func TestRefresh(t *testing.T) {
@@ -41,6 +43,7 @@ func TestRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -60,7 +63,20 @@ func TestRefresh(t *testing.T) {
 				sqlmock.NewRows([]string{"id", "epoch", "pool_id", "slot_qty", "slots", "hash"}),
 			)
 
-		clients.cardano.EXPECT().LeaderLogs(mock.Anything, "current", "nonce", pools[0]).Return(nil)
+		clients.cardano.EXPECT().LeaderLogs(mock.Anything, "current", "nonce", pools[0]).Return(
+			cardano.ClientLeaderLogsResponse{
+				Status: "ok",
+				AssignedSlots: []cardano.SlotSchedule{
+					{Slot: 1000},
+					{Slot: 2000},
+				},
+			},
+			nil,
+		)
+
+		db.mock.ExpectExec("INSERT INTO slots (epoch, pool_id, slot_qty, slots, hash) VALUES (?, ?, ?, ?, ?)").
+			WithArgs(epoch, pools[0].ID, 2, "[1000,2000]", "").
+			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		db.mock.ExpectQuery("SELECT * FROM slots WHERE pool_id = ? AND epoch = ?").
 			WithArgs(pools[0].ID, epoch).
@@ -75,7 +91,7 @@ func TestRefresh(t *testing.T) {
 				),
 			)
 
-		err := slotLeaderService.Refresh(context.Background(), blockfrost.Epoch{Epoch: epoch})
+		err := slotLeaderService.RefreshCurrent(context.Background(), blockfrost.Epoch{Epoch: epoch})
 		require.NoError(t, err)
 
 		b := bytes.NewBufferString(registry.metricsExpectedOutput)
@@ -106,6 +122,7 @@ func TestRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -145,7 +162,7 @@ func TestRefresh(t *testing.T) {
 				),
 			)
 
-		err := slotLeaderService.Refresh(context.Background(), blockfrost.Epoch{Epoch: epoch})
+		err := slotLeaderService.RefreshCurrent(context.Background(), blockfrost.Epoch{Epoch: epoch})
 		require.NoError(t, err)
 
 		b := bytes.NewBufferString(registry.metricsExpectedOutput)
@@ -172,6 +189,7 @@ func TestRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -188,7 +206,7 @@ func TestRefresh(t *testing.T) {
 		db.mock.ExpectQuery("SELECT * FROM slots WHERE pool_id = ? AND epoch = ?").
 			WithArgs(pools[0].ID, epoch).WillReturnError(errors.New("timeout"))
 
-		err := slotLeaderService.Refresh(context.Background(), blockfrost.Epoch{Epoch: epoch})
+		err := slotLeaderService.RefreshCurrent(context.Background(), blockfrost.Epoch{Epoch: epoch})
 		require.ErrorContains(t, err, "unable to check if slots are already refreshed for pool")
 
 		b := bytes.NewBufferString(registry.metricsExpectedOutput)
@@ -215,6 +233,7 @@ func TestRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -245,7 +264,7 @@ func TestRefresh(t *testing.T) {
 			WithArgs(pools[0].ID, epoch).
 			WillReturnError(errors.New("timeout"))
 
-		err := slotLeaderService.Refresh(context.Background(), blockfrost.Epoch{Epoch: epoch})
+		err := slotLeaderService.RefreshCurrent(context.Background(), blockfrost.Epoch{Epoch: epoch})
 		require.ErrorContains(t, err, "unable to get slot leaders for pool")
 
 		b := bytes.NewBufferString(registry.metricsExpectedOutput)
@@ -272,6 +291,7 @@ func TestRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -282,7 +302,7 @@ func TestRefresh(t *testing.T) {
 				errors.New("timeout"),
 			)
 
-		err := slotLeaderService.Refresh(context.Background(), blockfrost.Epoch{Epoch: epoch})
+		err := slotLeaderService.RefreshCurrent(context.Background(), blockfrost.Epoch{Epoch: epoch})
 		require.ErrorContains(t, err, "unable to get epoch parameters")
 
 		b := bytes.NewBufferString(registry.metricsExpectedOutput)
@@ -309,6 +329,7 @@ func TestRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -328,9 +349,9 @@ func TestRefresh(t *testing.T) {
 				sqlmock.NewRows([]string{"id", "epoch", "pool_id", "slot_qty", "slots", "hash"}),
 			)
 
-		clients.cardano.EXPECT().LeaderLogs(mock.Anything, "current", "nonce", pools[0]).Return(errors.New("cardano timeout"))
+		clients.cardano.EXPECT().LeaderLogs(mock.Anything, "current", "nonce", pools[0]).Return(cardano.ClientLeaderLogsResponse{}, errors.New("cardano timeout"))
 
-		err := slotLeaderService.Refresh(context.Background(), blockfrost.Epoch{Epoch: epoch})
+		err := slotLeaderService.RefreshCurrent(context.Background(), blockfrost.Epoch{Epoch: epoch})
 		require.ErrorContains(t, err, "unable to refresh slot leaders for pool")
 
 		b := bytes.NewBufferString(registry.metricsExpectedOutput)
@@ -357,6 +378,7 @@ func TestGetNextSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -393,6 +415,7 @@ func TestGetNextSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -420,6 +443,7 @@ func TestGetNextSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -449,6 +473,7 @@ func TestGetNextSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -488,6 +513,7 @@ func TestIsRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -522,6 +548,7 @@ func TestIsRefresh(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -553,6 +580,7 @@ func TestIsSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -583,6 +611,7 @@ func TestIsSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -613,6 +642,7 @@ func TestIsSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -640,6 +670,7 @@ func TestIsSlotLeader(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -668,6 +699,7 @@ func TestIsSlotEmpty(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -698,6 +730,7 @@ func TestIsSlotEmpty(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks
@@ -728,6 +761,7 @@ func TestIsSlotEmpty(t *testing.T) {
 			clients.cardano,
 			clients.bf, pools,
 			registry.metrics,
+			0,
 		)
 
 		// setup mocks

--- a/internal/slotleader/types.go
+++ b/internal/slotleader/types.go
@@ -15,7 +15,7 @@ import (
 )
 
 type SlotLeader interface {
-	Refresh(ctx context.Context, epoch bfAPI.Epoch) error
+	RefreshCurrent(ctx context.Context, epoch bfAPI.Epoch) error
 	IsSlotLeader(ctx context.Context, PoolID string, slot int, epoch int) (bool, error)
 	IsSlotsEmpty(ctx context.Context, PoolID string, epoch int) (bool, error)
 	GetSlotLeaders(ctx context.Context, PoolID string, epoch int) (Schedule, error)
@@ -23,12 +23,13 @@ type SlotLeader interface {
 }
 
 type Service struct {
-	db         *sqlx.DB
-	logger     *slog.Logger
-	pools      pools.Pools
-	cardano    cardano.CardanoClient
-	blockfrost blockfrost.Client
-	metrics    *metrics.Collection
+	db          *sqlx.DB
+	logger      *slog.Logger
+	pools       pools.Pools
+	cardano     cardano.CardanoClient
+	blockfrost  blockfrost.Client
+	metrics     *metrics.Collection
+	concurrency int
 }
 
 type slots []int

--- a/internal/watcher/watcher_block.go
+++ b/internal/watcher/watcher_block.go
@@ -227,7 +227,7 @@ func (w *BlockWatcher) handleEpochtransition(ctx context.Context) error {
 
 	// Update the slot leader schedule for each pool
 	w.logger.InfoContext(ctx, "🔄 Refreshing slot leader schedule for the new epoch", slog.Int("epoch", epoch.Epoch))
-	if err := w.slotLeaderService.Refresh(ctx, epoch); err != nil {
+	if err := w.slotLeaderService.RefreshCurrent(ctx, epoch); err != nil {
 		return fmt.Errorf("handleEpochTransition: failed to refresh slot leader schedule for the new epoch: %w", err)
 	}
 

--- a/internal/watcher/watcher_block_test.go
+++ b/internal/watcher/watcher_block_test.go
@@ -947,7 +947,7 @@ cardano_validator_watcher_validated_blocks_total{epoch="101",pool_id="pool-0",po
 			).
 			Return(blockfrost.Epoch{Epoch: nextEpoch}, nil)
 
-		clients.sl.EXPECT().Refresh(
+		clients.sl.EXPECT().RefreshCurrent(
 			mock.Anything,
 			blockfrost.Epoch{Epoch: nextEpoch},
 		).Return(nil)


### PR DESCRIPTION
- **fix: isolate cncli leaderlog with per-pool temp sqlite db**
- **feat: persist slots from leaderlog response and run parallel refresh**
- **feat: add configurable concurrency and next epoch scheduler**
