### PR TITLE
fix: use cardano-cli for next epoch slot schedule to avoid Blockfrost 404

### DIFF
--- a/internal/cardano/cardano.go
+++ b/internal/cardano/cardano.go
@@ -8,6 +8,7 @@ import (
 
 type CardanoClient interface {
 	LeaderLogs(ctx context.Context, ledgerSet string, epochNonce string, pool pools.Pool) (ClientLeaderLogsResponse, error)
+	LeaderLogsNextEpoch(ctx context.Context, pool pools.Pool) (ClientLeaderLogsResponse, error)
 	StakeSnapshot(ctx context.Context, PoolID string) (ClientQueryStakeSnapshotResponse, error)
 	Ping(ctx context.Context) error
 }

--- a/internal/cardano/cardanocli/cardano.go
+++ b/internal/cardano/cardanocli/cardano.go
@@ -42,6 +42,20 @@ type ClientOptions struct {
 	Timezone   string
 }
 
+func (c *Client) appendNetworkArgs(args []string) []string {
+	switch c.opts.Network {
+	case "mainnet":
+		return append(args, "--mainnet")
+	case "preprod":
+		return append(args, "--testnet-magic", "1")
+	case "sanchonet":
+		return append(args, "--testnet-magic", "4")
+	case "preview":
+		return append(args, "--testnet-magic", "2")
+	}
+	return args
+}
+
 func NewClient(opts ClientOptions, blockfrost blockfrost.Client, executor CommandExecutor) *Client {
 	logger := slog.With(
 		slog.String("component", "cardano-client"),
@@ -60,16 +74,7 @@ func (c *Client) Ping(ctx context.Context) error {
 		"--socket-path", c.opts.SocketPath,
 	}
 
-	switch c.opts.Network {
-	case "mainnet":
-		args = append(args, "--mainnet")
-	case "preprod":
-		args = append(args, "--testnet-magic", "1")
-	case "sanchonet":
-		args = append(args, "--testnet-magic", "4")
-	case "preview":
-		args = append(args, "--testnet-magic", "2")
-	}
+	args = c.appendNetworkArgs(args)
 
 	c.logger.DebugContext(ctx, "querying cardano node tip",
 		slog.String("cmd", fmt.Sprintf("cardano-cli %s", strings.Join(args, " "))),
@@ -95,16 +100,7 @@ func (c *Client) StakeSnapshot(ctx context.Context, PoolID string) (cardano.Clie
 		c.opts.SocketPath,
 	}
 
-	switch c.opts.Network {
-	case "mainnet":
-		args = append(args, "--mainnet")
-	case "preprod":
-		args = append(args, "--testnet-magic", "1")
-	case "sanchonet":
-		args = append(args, "--testnet-magic", "4")
-	case "preview":
-		args = append(args, "--testnet-magic", "2")
-	}
+	args = c.appendNetworkArgs(args)
 
 	output, err := c.executor.ExecCommand(ctx, stakeSnapshotTimeout, nil, "cardano-cli", args...)
 	if err != nil {
@@ -118,6 +114,66 @@ func (c *Client) StakeSnapshot(ctx context.Context, PoolID string) (cardano.Clie
 	}
 
 	return response, nil
+}
+
+func (c *Client) LeaderLogsNextEpoch(ctx context.Context, pool pools.Pool) (cardano.ClientLeaderLogsResponse, error) {
+	shelleyGenesisfile := filepath.Join(c.opts.ConfigDir, "shelley.json")
+	if _, err := os.Stat(shelleyGenesisfile); errors.Is(err, os.ErrNotExist) {
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to find shelley genesis file: %w", err)
+	}
+
+	if _, err := os.Stat(pool.Key); errors.Is(err, os.ErrNotExist) {
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to find pool vrf skey file: %w", err)
+	}
+
+	args := []string{
+		"conway", "query", "leadership-schedule",
+		"--genesis", shelleyGenesisfile,
+		"--stake-pool-id", pool.ID,
+		"--vrf-signing-key-file", pool.Key,
+		"--next",
+		"--socket-path", c.opts.SocketPath,
+	}
+
+	args = c.appendNetworkArgs(args)
+
+	output, err := c.executor.ExecCommand(ctx, leaderLogsTimeout, nil, "cardano-cli", args...)
+	if err != nil {
+		c.logger.ErrorContext(ctx,
+			fmt.Sprintf("unable to execute cardano-cli leadership-schedule command: %v", err),
+			slog.String("pool_name", pool.Name),
+			slog.String("pool_id", pool.ID),
+		)
+		fmt.Fprint(os.Stdout, string(output))
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("cardano-cli leadership-schedule: %w", err)
+	}
+
+	type entry struct {
+		SlotNumber int    `json:"slotNumber"`
+		SlotTime   string `json:"slotTime"`
+	}
+	var entries []entry
+	if err := json.Unmarshal(output, &entries); err != nil {
+		return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to unmarshal leadership-schedule response: %w", err)
+	}
+
+	slots := make([]cardano.SlotSchedule, len(entries))
+	for i, e := range entries {
+		t, err := time.Parse(time.RFC3339, e.SlotTime)
+		if err != nil {
+			return cardano.ClientLeaderLogsResponse{}, fmt.Errorf("unable to parse slot time %q: %w", e.SlotTime, err)
+		}
+		slots[i] = cardano.SlotSchedule{
+			No:   i + 1,
+			Slot: e.SlotNumber,
+			At:   t,
+		}
+	}
+
+	return cardano.ClientLeaderLogsResponse{
+		Status:        "ok",
+		AssignedSlots: slots,
+	}, nil
 }
 
 func (c *Client) LeaderLogs(ctx context.Context, ledgerSet string, epochNonce string, pool pools.Pool) (cardano.ClientLeaderLogsResponse, error) {

--- a/internal/cardano/cardanocli/cardano_test.go
+++ b/internal/cardano/cardanocli/cardano_test.go
@@ -241,3 +241,60 @@ func TestLeaderLogs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedOutput, response)
 }
+
+func TestLeaderLogsNextEpoch(t *testing.T) {
+	pool := pools.Pool{
+		Instance: "pool-0",
+		ID:       "pool-0",
+		Name:     "pool-0",
+		Key:      "pool-0.vrf.skey",
+	}
+	clientopts := ClientOptions{
+		Network:    "preprod",
+		SocketPath: "/tmp/cardano.socket",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	clientopts.ConfigDir = dir
+	_, _ = os.Create(filepath.Join(clientopts.ConfigDir, "shelley.json"))
+	vrf, _ := os.Create("pool-0.vrf.skey")
+	defer func() {
+		os.RemoveAll(clientopts.ConfigDir)
+		os.Remove(vrf.Name())
+	}()
+
+	cardanoCLIOutput := `[{"slotNumber":185071693,"slotTime":"2026-04-19T22:33:04Z"},{"slotNumber":185072489,"slotTime":"2026-04-19T22:46:20Z"}]`
+
+	exec := &mocks.MockCommandExecutor{}
+	exec.EXPECT().ExecCommand(
+		ctx,
+		leaderLogsTimeout,
+		([]string)(nil),
+		"cardano-cli",
+		"conway", "query", "leadership-schedule",
+		"--genesis", filepath.Join(clientopts.ConfigDir, "shelley.json"),
+		"--stake-pool-id", pool.ID,
+		"--vrf-signing-key-file", vrf.Name(),
+		"--next",
+		"--socket-path", clientopts.SocketPath,
+		"--testnet-magic", "1",
+	).Return([]byte(cardanoCLIOutput), nil)
+
+	expectedAt0, _ := time.Parse(time.RFC3339, "2026-04-19T22:33:04Z")
+	expectedAt1, _ := time.Parse(time.RFC3339, "2026-04-19T22:46:20Z")
+	expected := cardano.ClientLeaderLogsResponse{
+		Status: "ok",
+		AssignedSlots: []cardano.SlotSchedule{
+			{No: 1, Slot: 185071693, At: expectedAt0},
+			{No: 2, Slot: 185072489, At: expectedAt1},
+		},
+	}
+
+	client := NewClient(clientopts, nil, exec)
+	response, err := client.LeaderLogsNextEpoch(ctx, pool)
+	require.NoError(t, err)
+	require.Equal(t, expected, response)
+}

--- a/internal/cardano/mocks/mock_CardanoClient.go
+++ b/internal/cardano/mocks/mock_CardanoClient.go
@@ -84,6 +84,63 @@ func (_c *MockCardanoClient_LeaderLogs_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// LeaderLogsNextEpoch provides a mock function with given fields: ctx, pool
+func (_m *MockCardanoClient) LeaderLogsNextEpoch(ctx context.Context, pool pools.Pool) (cardano.ClientLeaderLogsResponse, error) {
+	ret := _m.Called(ctx, pool)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LeaderLogsNextEpoch")
+	}
+
+	var r0 cardano.ClientLeaderLogsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, pools.Pool) (cardano.ClientLeaderLogsResponse, error)); ok {
+		return rf(ctx, pool)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, pools.Pool) cardano.ClientLeaderLogsResponse); ok {
+		r0 = rf(ctx, pool)
+	} else {
+		r0 = ret.Get(0).(cardano.ClientLeaderLogsResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, pools.Pool) error); ok {
+		r1 = rf(ctx, pool)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCardanoClient_LeaderLogsNextEpoch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LeaderLogsNextEpoch'
+type MockCardanoClient_LeaderLogsNextEpoch_Call struct {
+	*mock.Call
+}
+
+// LeaderLogsNextEpoch is a helper method to define mock.On call
+//   - ctx context.Context
+//   - pool pools.Pool
+func (_e *MockCardanoClient_Expecter) LeaderLogsNextEpoch(ctx interface{}, pool interface{}) *MockCardanoClient_LeaderLogsNextEpoch_Call {
+	return &MockCardanoClient_LeaderLogsNextEpoch_Call{Call: _e.mock.On("LeaderLogsNextEpoch", ctx, pool)}
+}
+
+func (_c *MockCardanoClient_LeaderLogsNextEpoch_Call) Run(run func(ctx context.Context, pool pools.Pool)) *MockCardanoClient_LeaderLogsNextEpoch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(pools.Pool))
+	})
+	return _c
+}
+
+func (_c *MockCardanoClient_LeaderLogsNextEpoch_Call) Return(_a0 cardano.ClientLeaderLogsResponse, _a1 error) *MockCardanoClient_LeaderLogsNextEpoch_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCardanoClient_LeaderLogsNextEpoch_Call) RunAndReturn(run func(context.Context, pools.Pool) (cardano.ClientLeaderLogsResponse, error)) *MockCardanoClient_LeaderLogsNextEpoch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Ping provides a mock function with given fields: ctx
 func (_m *MockCardanoClient) Ping(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/internal/slotleader/slotleader.go
+++ b/internal/slotleader/slotleader.go
@@ -73,9 +73,13 @@ func (s *Service) refresh(ctx context.Context, epoch bfAPI.Epoch, ledgerSet stri
 		)
 	}
 
-	epochParams, err := s.blockfrost.GetEpochParameters(ctx, epoch.Epoch)
-	if err != nil {
-		return fmt.Errorf("slotLeader: unable to get epoch parameters: %w", err)
+	var epochNonce string
+	if ledgerSet != "next" {
+		epochParams, err := s.blockfrost.GetEpochParameters(ctx, epoch.Epoch)
+		if err != nil {
+			return fmt.Errorf("slotLeader: unable to get epoch parameters: %w", err)
+		}
+		epochNonce = epochParams.Nonce
 	}
 
 	for _, pool := range activePools {
@@ -91,7 +95,12 @@ func (s *Service) refresh(ctx context.Context, epoch bfAPI.Epoch, ledgerSet stri
 						fmt.Sprintf("⏰ refreshing slots for pool: %s", pool.Name),
 						slog.String("pool_id", pool.ID),
 					)
-					response, err := s.cardano.LeaderLogs(ctx, ledgerSet, epochParams.Nonce, pool)
+					var response cardano.ClientLeaderLogsResponse
+					if ledgerSet == "next" {
+						response, err = s.cardano.LeaderLogsNextEpoch(ctx, pool)
+					} else {
+						response, err = s.cardano.LeaderLogs(ctx, ledgerSet, epochNonce, pool)
+					}
 					if err != nil {
 						return &ErrSlotLeaderRefresh{PoolID: pool.ID, Epoch: epoch.Epoch, Message: err.Error()}
 					}

--- a/internal/slotleader/slotleader_test.go
+++ b/internal/slotleader/slotleader_test.go
@@ -360,6 +360,104 @@ func TestRefresh(t *testing.T) {
 	})
 }
 
+func TestRefreshNext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GoodPath_RefreshNextEpoch", func(t *testing.T) {
+		t.Parallel()
+
+		clients := setupClients(t)
+		pools := setupPools(t)
+		db := setupDB(t)
+		registry := setupRegistry(t)
+		nextEpoch := 101
+
+		registry.metricsExpectedOutput = `
+		# HELP cardano_validator_watcher_expected_blocks number of expected blocks in the current epoch
+		# TYPE cardano_validator_watcher_expected_blocks gauge
+		cardano_validator_watcher_expected_blocks{epoch="101", pool_id="pool-0", pool_instance="pool-0", pool_name="pool-0"} 2
+		`
+		registry.metricsUnderTest = []string{
+			"cardano_validator_watcher_expected_blocks",
+		}
+
+		slotLeaderService := NewSlotLeaderService(
+			db.db,
+			clients.cardano,
+			clients.bf, pools,
+			registry.metrics,
+			0,
+		)
+
+		db.mock.ExpectQuery("SELECT * FROM slots WHERE pool_id = ? AND epoch = ?").
+			WithArgs(pools[0].ID, nextEpoch).
+			WillReturnRows(
+				sqlmock.NewRows([]string{"id", "epoch", "pool_id", "slot_qty", "slots", "hash"}),
+			)
+
+		clients.cardano.EXPECT().LeaderLogsNextEpoch(mock.Anything, pools[0]).Return(
+			cardano.ClientLeaderLogsResponse{
+				Status: "ok",
+				AssignedSlots: []cardano.SlotSchedule{
+					{Slot: 1000},
+					{Slot: 2000},
+				},
+			},
+			nil,
+		)
+
+		db.mock.ExpectExec("INSERT INTO slots (epoch, pool_id, slot_qty, slots, hash) VALUES (?, ?, ?, ?, ?)").
+			WithArgs(nextEpoch, pools[0].ID, 2, "[1000,2000]", "").
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		db.mock.ExpectQuery("SELECT * FROM slots WHERE pool_id = ? AND epoch = ?").
+			WithArgs(pools[0].ID, nextEpoch).
+			WillReturnRows(
+				sqlmock.NewRows([]string{"id", "epoch", "pool_id", "slot_qty", "slots", "hash"}).AddRow(
+					1, nextEpoch, pools[0].ID, 2, "[1000, 2000]", "hash",
+				),
+			)
+
+		err := slotLeaderService.RefreshNext(context.Background(), blockfrost.Epoch{Epoch: nextEpoch}, 0)
+		require.NoError(t, err)
+
+		b := bytes.NewBufferString(registry.metricsExpectedOutput)
+		err = testutil.CollectAndCompare(registry.registry, b, registry.metricsUnderTest...)
+		require.NoError(t, err)
+	})
+
+	t.Run("SadPath_RefreshNext_UnableToCalculateLeaderLogs", func(t *testing.T) {
+		t.Parallel()
+
+		clients := setupClients(t)
+		pools := setupPools(t)
+		db := setupDB(t)
+		registry := setupRegistry(t)
+		nextEpoch := 101
+
+		slotLeaderService := NewSlotLeaderService(
+			db.db,
+			clients.cardano,
+			clients.bf, pools,
+			registry.metrics,
+			0,
+		)
+
+		db.mock.ExpectQuery("SELECT * FROM slots WHERE pool_id = ? AND epoch = ?").
+			WithArgs(pools[0].ID, nextEpoch).
+			WillReturnRows(
+				sqlmock.NewRows([]string{"id", "epoch", "pool_id", "slot_qty", "slots", "hash"}),
+			)
+
+		clients.cardano.EXPECT().LeaderLogsNextEpoch(mock.Anything, pools[0]).Return(
+			cardano.ClientLeaderLogsResponse{}, errors.New("cardano-cli timeout"),
+		)
+
+		err := slotLeaderService.RefreshNext(context.Background(), blockfrost.Epoch{Epoch: nextEpoch}, 0)
+		require.ErrorContains(t, err, "unable to refresh slot leaders for pool")
+	})
+}
+
 func TestGetNextSlotLeader(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

`RunNextEpochScheduler` was calling `GetEpochParameters(ctx, epoch+1)` via Blockfrost to get the nonce for cncli, but epoch N+1 doesn't exist yet in Blockfrost, causing a 404 error:

```
error="slotLeader: unable to get epoch parameters: API Error, {Error:Not Found Message:The requested component has not been found. StatusCode:404}"
```

## Solution

Use `cardano-cli conway query leadership-schedule --next` for the next epoch calculation. Unlike cncli, cardano-cli handles the nonce internally via the node socket, requiring no Blockfrost call for a future epoch.

Benchmark confirmed identical results between cncli and cardano-cli for all 12 pools.

## Changes

- Add `LeaderLogsNextEpoch` to `CardanoClient` interface, implemented with `cardano-cli conway query leadership-schedule --next`
- Skip `GetEpochParameters` in `refresh()` when `ledger-set` is `next`
- Extract `appendNetworkArgs()` helper to remove duplicated switch blocks across `Ping`, `StakeSnapshot`, and the new method
- Add tests for `LeaderLogsNextEpoch` and `RefreshNext`